### PR TITLE
IE 11 scrollbar blur() bug

### DIFF
--- a/src/jquery-editable-select.js
+++ b/src/jquery-editable-select.js
@@ -144,7 +144,14 @@
 			case 'focus':
 				that.es.$input
 					.on('focus', $.proxy(that.es.show, that.es))
-					.on('blur', $.proxy(that.es.hide, that.es));
+				        .on("blur", $.proxy(function() {
+						if ($(".es-list:hover").length === 0) {
+							that.es.hide();
+						} else {
+							this.$input.focus();
+						}
+					}, that.es
+				    ));
 				break;
 			case 'manual':
 				break;


### PR DESCRIPTION
This fix is to address the dropdown disappearing in IE 11 when the user attempts to click the scroll bar.  When the user clicks the scrollbar, the blur event was being triggered and causing the dropdown to close.  The fix determines whether the user is still hovering over the list and prevents the dropdown from closing if so.