### PR TITLE
Use jQuery $.inArray function instead of Array.indexOf

### DIFF
--- a/src/jquery-editable-select.js
+++ b/src/jquery-editable-select.js
@@ -16,9 +16,9 @@
 		this.$list   = $('<ul class="es-list">');
 		this.utility = new EditableSelectUtility(this);
 		
-		if (['focus', 'manual'].indexOf(this.options.trigger) < 0) this.options.trigger = 'focus';
-		if (['default', 'fade', 'slide'].indexOf(this.options.effects) < 0) this.options.effects = 'default';
-		if (isNaN(this.options.duration) && ['fast', 'slow'].indexOf(this.options.duration) < 0) this.options.duration = 'fast';
+		if ($.inArray(this.options.trigger,['focus', 'manual']) < 0) this.options.trigger = 'focus';
+		if ($.inArray(this.options.effects,['default', 'fade', 'slide']) < 0) this.options.effects = 'default';
+		if (isNaN(this.options.duration) && $.inArray(this.options.duration,['fast', 'slow']) < 0) this.options.duration = 'fast';
 		
 		// create text input
 		this.$select.replaceWith(this.$input);


### PR DESCRIPTION
Array.indexOf is not available in IE8 and polyfills in IE8 are added as enumerable properties, so they break existing code relying on for..in enumeration. This allows the component to work inside SharePoint 2010, which requires IE8 emulation even in newest IE browsers (i.e. IE11).